### PR TITLE
Implementatie wijziging knoptekst naar "Kleur bewaren" in UC4

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Kleur Bewaren" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
Deze pull request past de knoptekst aan binnen UC4. De oude tekst "wijzig kleur" is vervangen door "Kleur bewaren" om consistentie en duidelijkheid voor de gebruiker te verbeteren.
De wijziging betreft uitsluitend de XAML van de betreffende pagina; functionaliteit en commandbinding blijven ongewijzigd.